### PR TITLE
Adds static-analyzers support for CMake workflow

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,28 @@
+---
+# Adapted from drake's configuration file (link below)
+# https://github.com/RobotLocomotion/drake/blob/master/.clang-tidy
+
+Checks: >
+        clang-analyzer-*,
+        clang-diagnostic-*,
+        cppcoreguidelines-*,
+        google-*,
+        modernize-*,
+        performance-*,
+        readability-*,
+        -readability-redundant-access-specifiers,
+
+WarningsAsErrors: ''
+FormatStyle: none
+HeaderFilterRegex: ''
+
+CheckOptions:
+  - { key: readability-identifier-naming.ClassCase,             value: CamelCase  }
+  - { key: readability-identifier-naming.NamespaceCase,         value: lower_case }
+  - { key: readability-identifier-naming.PrivateMemberPrefix,   value: 'm_'        }
+  - { key: readability-identifier-naming.StaticVariablePrefix,  value: 's_' }
+  - { key: readability-identifier-naming.StructCase,            value: CamelCase  }
+  - { key: readability-identifier-naming.VariableCase,          value: lower_case }
+  - { key: readability-identifier-naming.ConstantCase,          value: UPPER_CASE }
+  - { key: readability-identifier-naming.ConstexprVariableCase, value: UPPER_CASE }
+...

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -33,6 +33,10 @@ jobs:
         with:
           cmake-version: ${{matrix.cmake-version}}
 
+      - name: Setup Ninja
+        if: ${{ matrix.generator == 'Ninja' }}
+        uses: ashutoshvarma/setup-ninja@master
+
       # Configure for GCC
       - name: Configure GNU/GCC as C/C++ compiler
         if: ${{ matrix.compiler == 'gcc' }}

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04]
         build-type: [Release, Debug]
-        cmake-version: [3.15.x, 3.18.x, 3.21.x, 3.23.x]
+        cmake-version: [3.15.x, 3.23.x]
         compiler: [gcc, clang]
         generator: [Unix Makefiles, Ninja]
 

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -16,8 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04]
-        build-type: [Release, RelWithDebInfo, MinSizeRel, Debug]
-        cmake-version: [3.15.x, 3.16.x, 3.17.x, 3.18.x, 3.19.x, 3.20.x, 3.21.x]
+        build-type: [Release, Debug]
+        cmake-version: [3.15.x, 3.18.x, 3.21.x, 3.23.x]
         compiler: [gcc, clang]
         generator: [Unix Makefiles, Ninja]
 

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -60,4 +60,5 @@ jobs:
       - name: Run examples
         run: |
           chmod +x scripts/run_examples.sh
-          bash scripts/run_examples.sh ${{matrix.build-type}}
+          bash scripts/run_examples.sh clean
+          bash scripts/run_examples.sh build ${{matrix.build-type}}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2019, windows-2022]
-        build-type: [Release, RelWithDebInfo, MinSizeRel, Debug]
+        build-type: [Release, Debug]
         cmake-version: [3.21.x, 3.22.x, 3.23.x]
 
     name: "Build: ${{matrix.os}} • ${{matrix.build-type}} • ${{matrix.cmake-version}} • MSVC"

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [windows-2019, windows-2022]
         build-type: [Release, Debug]
-        cmake-version: [3.21.x, 3.22.x, 3.23.x]
+        cmake-version: [3.23.x]
 
     name: "Build: ${{matrix.os}} • ${{matrix.build-type}} • ${{matrix.cmake-version}} • MSVC"
     runs-on: ${{matrix.os}}

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ Testing/
 
 # Exclude settings from editors|IDEs
 .vscode
+.clangd
 
 # Exclude temporary folders
 *.egg-info/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,8 @@ repos:
     -   id: trailing-whitespace
     -   id: mixed-line-ending
         args: [--fix=lf]
+    -   id: no-commit-to-branch
+        args: [--branch, main]
 
 # Applies formating and linting to CMake files
 -   repo: https://github.com/cheshirekow/cmake-format-precommit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,13 @@ repos:
     rev: v1.1.7
     hooks:
     -   id: remove-tabs
+
+# Applies static-analysis tools
+-   repo: https://github.com/pocc/pre-commit-hooks
+    rev: v1.3.4
+    hooks:
+    -   id: clang-format
+        args: [-i]
+    -   id: clang-tidy
+    -   id: cpplint
+    -   id: cppcheck

--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -1,10 +1,11 @@
 # Adapted from drake's configuration file (link below)
 # https://github.com/RobotLocomotion/drake/blob/master/CPPLINT.cfg
 
+# This is the top-level config file (don't look upwards)
+set noparent
+
 # Disable a warning about C++ features that were not in the original
-# C++11 specification (and so might not be well-supported).  In the
-# case of Drake, our supported minimum platforms are new enough that
-# this warning is irrelevant.
+# C++11 specification (and so might not be well-supported)
 filter=-build/c++11
 
 # We use '#pragma once' instead of include-guards

--- a/examples/target/CMakeLists.txt
+++ b/examples/target/CMakeLists.txt
@@ -13,6 +13,10 @@ project(ExampleTarget VERSION 1.0.0)
 loco_initialize_project()
 
 # -------------------------------------
+# Setup static analyzers
+loco_setup_cppcheck()
+
+# -------------------------------------
 # Checking a simple target of type INTERFACE
 add_library(target_interface_lib INTERFACE)
 loco_setup_target(target_interface_lib WARNINGS_AS_ERRORS TRUE)

--- a/examples/target/CMakeLists.txt
+++ b/examples/target/CMakeLists.txt
@@ -16,6 +16,7 @@ loco_initialize_project()
 # Setup static analyzers
 loco_setup_cppcheck()
 loco_setup_cpplint()
+loco_setup_clang_tidy()
 
 # -------------------------------------
 # Checking a simple target of type INTERFACE

--- a/examples/target/CMakeLists.txt
+++ b/examples/target/CMakeLists.txt
@@ -15,6 +15,7 @@ loco_initialize_project()
 # -------------------------------------
 # Setup static analyzers
 loco_setup_cppcheck()
+loco_setup_cpplint()
 
 # -------------------------------------
 # Checking a simple target of type INTERFACE

--- a/examples/utils/sample_exec.cpp
+++ b/examples/utils/sample_exec.cpp
@@ -2,6 +2,6 @@
 #include <iostream>
 
 auto main() -> int {
-  std::cout << "Just a dummy executable" << '\n';
-  return EXIT_SUCCESS;
+    std::cout << "Just a dummy executable" << '\n';
+    return EXIT_SUCCESS;
 }

--- a/examples/utils/sample_lib.cpp
+++ b/examples/utils/sample_lib.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
 
 auto dummy_lib_function() -> void {
-  std::cout << "Just a dummy lib function" << '\n';
+    std::cout << "Just a dummy lib function" << '\n';
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pre-commit
-cmakelang[YAML]
+cmakelang
 cpplint
 yamllint
 pylint

--- a/scripts/run_examples.sh
+++ b/scripts/run_examples.sh
@@ -2,15 +2,29 @@
 
 # Make sure we're given the build-type argument by the user
 build_type="Debug"
-if [[ $# != 1 ]]; then
-    echo "Usage ./run_examples.sh [config=Debug,Release,RelWithDebInfo,MinSizeRel]"
+if [[ $# < 1 || $# > 2 ]]; then
+    echo "Usage ./run_examples.sh [mode=build,clean] [config=Debug,Release,RelWithDebInfo,MinSizeRel]"
     exit 1
 fi
 
+curr_mode=$1
+mode_types=("build" "clean")
+mode_valid=false
+for valid_mode_type in ${mode_types[@]}; do
+    if [[ ${curr_mode} -eq ${valid_mode_type} ]]; then
+        mode_valid=true
+    fi
+done
+if [[ ${mode_valid} != true ]]; then
+    echo "Valid mode options: [mode=build,clean]"
+    exit 1
+fi
+
+curr_build_type=$2
 build_types=("Debug" "Release" "RelWithDebInfo" "MinSizeRel")
 build_valid=false
 for valid_build_type in ${build_types[@]}; do
-    if [[ $1 -eq ${valid_build_type} ]]; then
+    if [[ curr_build_type -eq ${valid_build_type} ]]; then
         build_valid=true
     fi
 done
@@ -26,13 +40,36 @@ root_dir="$(dirname -- ${scripts_dir})"
 examples_dir="${root_dir}/examples"
 ex_names=("project" "simd" "target" "utils")
 
-# Run each example|test
-for example_name in ${ex_names[@]}; do
-    source_folder="${examples_dir}/${example_name}"
-    build_folder="${examples_dir}/${example_name}/build"
+build_all_examples() {
+    for example_name in ${ex_names[@]}; do
+        # Define some paths we'll use later
+        source_folder="${examples_dir}/${example_name}"
+        build_folder="${examples_dir}/${example_name}/build"
+        # Run the configuration|generation step
+        echo "source-folder: ${source_folder}"
+        echo "build-folder: ${build_folder}"
+        cmake -S ${source_folder} -B ${build_folder} -DCMAKE_BUILD_TYPE=${curr_build_type} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+        # Make sure we copy the generated compile_commands.json (if it exists)
+        if [ -f "${build_folder}/compile_commands.json" ]; then
+            cp ${build_folder}/compile_commands.json ${source_folder}/compile_commands.json
+        fi
+        # Build our example using the generated configuration
+        cmake --build ${build_folder} --config ${curr_build_type}
+    done
+}
 
-    echo "source-folder: ${source_folder}"
-    echo "build-folder: ${build_folder}"
-    cmake -S ${source_folder} -B ${build_folder} -DCMAKE_BUILD_TYPE=$1
-    cmake --build ${build_folder} --config $1
-done
+clean_all_examples() {
+    for example_name in ${ex_names[@]}; do
+        build_folder="${examples_dir}/${example_name}/build"
+        if [ -d ${build_folder} ]; then
+            echo "Removing build-folder @ ${build_folder}"
+            rm -rf ${build_folder}
+        fi
+    done
+}
+
+if [[ ${curr_mode} == "build" ]]; then
+    build_all_examples
+elif [[ ${curr_mode} == "clean" ]]; then
+    clean_all_examples
+fi


### PR DESCRIPTION
# Description

Adds some helper macros to enable one of three available `C/C++` static-analayzers (`clang-tidy,cpplint,cppcheck`)